### PR TITLE
feat: 최근 도착지 조회 기능 추가

### DIFF
--- a/src/main/java/com/sesac/alltaxi/controller/MainController.java
+++ b/src/main/java/com/sesac/alltaxi/controller/MainController.java
@@ -6,10 +6,12 @@ import com.sesac.alltaxi.dto.*;
 import com.sesac.alltaxi.service.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import com.sesac.alltaxi.service.UserService;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import com.sesac.alltaxi.infra.S3Uploader;
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -24,6 +26,9 @@ public class MainController {
     @Autowired
     private S3Uploader s3Uploader;
 
+    @Autowired
+    private UserService userService;
+
     @PostMapping("/create-request")
     public ResponseEntity<ApiResponse<Long>> createRequest(@RequestBody RequestCreateDto requestCreateDto) {
         ApiResponse<Long> response = requestService.createRequestWithDestination(
@@ -34,6 +39,12 @@ public class MainController {
                 requestCreateDto.getLongitude()
         );
         return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("/user/{userId}/recent-addresses")
+    public ResponseEntity<List<String>> getRecentAddresses(@PathVariable Long userId) {
+        List<String> recentAddresses = userService.getRecentAddresses(userId);
+        return ResponseEntity.ok(recentAddresses);
     }
 
     @PostMapping("/set-pickup-point/{requestId}")

--- a/src/main/java/com/sesac/alltaxi/domain/User.java
+++ b/src/main/java/com/sesac/alltaxi/domain/User.java
@@ -17,6 +17,9 @@ public class User {
     private String name;
     private String phoneNumber;
 
+    @ElementCollection
+    private List<String> recentAddresses;
+
     @OneToMany(mappedBy = "user")
     private List<Request> requests;
 }

--- a/src/main/java/com/sesac/alltaxi/service/RequestService.java
+++ b/src/main/java/com/sesac/alltaxi/service/RequestService.java
@@ -17,6 +17,7 @@ import com.drew.metadata.Metadata;
 import com.drew.metadata.exif.GpsDirectory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -44,7 +45,24 @@ public class RequestService {
         request.setStatus("created");
 
         requestRepository.save(request);
+
+        updateRecentAddresses(user, placeName);
+
         return ApiResponse.ok(request.getId());
+    }
+
+    private void updateRecentAddresses(User user, String address) {
+        List<String> recentAddresses = user.getRecentAddresses();
+        if (recentAddresses == null) {
+            recentAddresses = new ArrayList<>();
+        }
+        recentAddresses.remove(address); // 중복 제거
+        recentAddresses.add(0, address); // 맨 앞에 추가
+        if (recentAddresses.size() > 3) {
+            recentAddresses.remove(3); // 최대 3개 유지
+        }
+        user.setRecentAddresses(recentAddresses);
+        userRepository.save(user);
     }
 
     public PickUpResponseDto setPickupPoint(MultipartFile image, Long requestId, String imageKey) throws ImageProcessingException, IOException {

--- a/src/main/java/com/sesac/alltaxi/service/UserService.java
+++ b/src/main/java/com/sesac/alltaxi/service/UserService.java
@@ -5,18 +5,17 @@ import com.sesac.alltaxi.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import java.util.List;
 
 @Service
 public class UserService {
+
     @Autowired
     private UserRepository userRepository;
 
-    public User saveUser(User user) {
-        return userRepository.save(user);
-    }
-
-    public Optional<User> getUserById(Long id) {
-        return userRepository.findById(id);
+    public List<String> getRecentAddresses(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return user.getRecentAddresses();
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ebe33f3e-04d6-43c7-9ebf-3c8d238db8d4)
해당 페이지에서 최근 목적지로 설정한 주소의 주소명을 조회하는 기능입니다! 

![image](https://github.com/user-attachments/assets/f513c075-6ad8-48eb-ad24-90a35184c112)
조회 데이터를 user 테이블 내 컬럼으로 저장할 시 각 컬럼(address1, address2...) 형식이 되어서, 
list 형식으로 user_recent_addresses 새로운 테이블로 관리되게끔 했습니다!